### PR TITLE
Only replace Date with FakeDate when necessary

### DIFF
--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -12,7 +12,6 @@
  */
 var NativeDate = Date;
 
-
 /**
  * `TimeKeeper`.
  *
@@ -121,6 +120,8 @@ FakeDate.now = function() {
  * @api public
  */
 timekeeper.freeze = function(date) {
+  useFakeDate();
+
   if (typeof date !== 'object') {
     date = new NativeDate(date);
   }
@@ -135,6 +136,8 @@ timekeeper.freeze = function(date) {
  * @api public
  */
 timekeeper.travel = function(date) {
+  useFakeDate();
+
   if (typeof date !== 'object') {
     date = new NativeDate(date);
   }
@@ -149,6 +152,7 @@ timekeeper.travel = function(date) {
  * @api public
  */
 timekeeper.reset = function() {
+  useNativeDate();
   freeze = null;
   started = null;
   travel = null;
@@ -157,7 +161,17 @@ timekeeper.reset = function() {
 /**
  * Replace the `Date` with `FakeDate`.
  */
-Date = FakeDate;
+function useFakeDate() {
+  Date = FakeDate
+}
+
+/**
+ * Restore the `Date` to `NativeDate`.
+ */
+function useNativeDate() {
+  Date = NativeDate
+}
+
 
 /**
  * Expose `timekeeper`


### PR DESCRIPTION
I see no reason to need to override the Date object with FakeDate until one of the timekeeper features is actually enabled. This pull request makes it so that Date is only replaced when timekeeper.freeze or timekeeper.travel is called. The original Date object is then restored when timekeeper.reset is called.

This solves issue #2 which is caused by the Mongoose not understanding what to do with FakeDate when it expects Date.
