### PR TITLE
Added setTimeout pausing and rescheduling based on freeze and travel

### DIFF
--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -13,6 +13,28 @@
 var NativeDate = Date;
 
 /**
+ * Native setTimeout reference.
+ *
+ * @type {Function}
+ */
+var nativeSetTimeout = setTimeout;
+
+/**
+ * Native clearTimeout reference.
+ *
+ * @type {Function}
+ */
+var nativeClearTimeout = clearTimeout;
+
+/**
+ * Collection of timeouts and times they should run
+ *
+ * @type {Object}
+ */
+var timeouts = [];
+
+
+/**
  * `TimeKeeper`.
  *
  * @type {Object}
@@ -114,6 +136,87 @@ FakeDate.now = function() {
 };
 
 /**
+ * Fake set timeout
+ *
+ * Stores timeouts to be run for pausing and restarting
+ *
+ * @returns {Object}
+ * @api public
+ */
+function fakeSetTimeout( func, delay ) {
+  var timeout = {
+    hasRun: false,
+    canceled: false,
+    shouldRunAt: Date.now() + delay,
+    args: Array.prototype.slice.call( arguments, 2 ),
+    run: function() {
+      if( !timeout.canceled && !timeout.hasRun ) {
+        timeout.hasRun = true;
+        timeouts.splice( timeouts.indexOf( timeout ), 1 );
+        func.apply( null, timeout.args );
+      }
+    },
+  };
+  timeouts.push( timeout );
+  if(!freeze) {
+    timeout.timeout = nativeSetTimeout( timeout.run, delay );
+  }
+  return timeout;
+};
+
+//For testing purposes
+timekeeper.nativeSetTimeout = nativeSetTimeout;
+
+/**
+ * Fake clear timeout
+ *
+ * Deletes a stored timeout
+ *
+ * @api public
+ */
+function fakeClearTimeout( timeout ) {
+  if( !timeout.hasRun ) {
+    timeout.canceled = true;
+    nativeClearTimeout( timeout.timeout );
+    timeouts.splice( timeouts.indexOf( timeout ), 1 );
+  }
+}
+
+/**
+ * Stop all pending timeouts and wait for time to start again
+ *
+ */
+
+function freezeTimeouts() {
+  for( var i = timeouts.length - 1; i >= 0; i-- ) { //Go backwards in case we get spliced externally
+    var timeout = timeouts[i];
+    if( timeout ) {
+      nativeClearTimeout( timeout.timeout );
+    }
+  }
+}
+
+/**
+ * Reschedule timeouts based on new time information
+ *
+ */
+
+function restartTimeouts() {
+  var now = Date.now();
+  for( var i = timeouts.length - 1; i >= 0; i-- ) { //Go backwards in case we get spliced externally
+    var timeout = timeouts[i];
+    if( timeout ) {
+        nativeClearTimeout( timeout.timeout );
+        var newDelay = timeout.shouldRunAt - now;
+        if( newDelay < 0 ) {
+          newDelay = 0;
+        }
+        timeout.timeout = nativeSetTimeout( timeout.run, newDelay );
+    }
+  }
+}
+
+/**
  * Set current Date Tieme and freeze it.
  *
  * @param {Object|String|Number} Date.
@@ -125,8 +228,10 @@ timekeeper.freeze = function(date) {
   if (typeof date !== 'object') {
     date = new NativeDate(date);
   }
-
+  travel = null;
+  started = null;
   freeze = date;
+  freezeTimeouts();
 };
 
 /**
@@ -141,9 +246,10 @@ timekeeper.travel = function(date) {
   if (typeof date !== 'object') {
     date = new NativeDate(date);
   }
-
+  freeze = null;
   travel = date.getTime();
   started = NativeDate.now();
+  restartTimeouts();
 };
 
 /**
@@ -156,6 +262,7 @@ timekeeper.reset = function() {
   freeze = null;
   started = null;
   travel = null;
+  restartTimeouts();
 };
 
 /**
@@ -171,14 +278,19 @@ timekeeper.isKeepingTime = function() {
  * Replace the `Date` with `FakeDate`.
  */
 function useFakeDate() {
-  Date = FakeDate
+  Date = FakeDate;
+  setTimeout = fakeSetTimeout;
+  clearTimeout = fakeClearTimeout;
 }
 
 /**
  * Restore the `Date` to `NativeDate`.
  */
 function useNativeDate() {
-  Date = NativeDate
+  Date = NativeDate;
+  setTimeout = nativeSetTimeout;
+  clearTimeout = nativeClearTimeout;
+  restartTimeouts();
 }
 
 

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -56,6 +56,20 @@ describe('TimeKeeper', function() {
         (new Date(1330688329320)).getTime().should.eql(1330688329320);
         tk.reset();
       });
+      
+      it('should not fire setTimeout functions', function(done) {
+        var called = false;
+        setTimeout( function() { 
+          called = true; 
+        }, 100 );
+        sleep( 120 );
+        tk.travel( this.time );
+        setTimeout( function() { 
+          called.should.be.eql( false ); 
+          done(); 
+        }, 1 );
+              
+      });
     });
   });
 
@@ -81,6 +95,22 @@ describe('TimeKeeper', function() {
           tk.reset();
         });
       });
+      
+      describe('and used with setTimeout', function() {
+        it('should reschedule functions scheduled with setTimeout', function( done ) {
+          var array = [];
+          setTimeout( function() { array.push( 1 ); }, 100 );  //t+50
+          tk.travel(new Date( this.time.getTime() - 200 ) );
+          setTimeout( function() { array.push( 2 ); }, 150 ); //t-50
+          tk.travel(new Date( this.time.getTime() - 450 ));
+          setTimeout( function() { array.push( 3 ); }, 200 ); //t-150
+          setTimeout( function() {
+            array.should.be.eql( [3, 2, 1] );
+            tk.reset();
+            done();
+          }, 1500 );
+        });
+      });
     });
   });
 
@@ -99,4 +129,6 @@ describe('TimeKeeper', function() {
       tk.isKeepingTime().should.be.eql(false);
     });
   });
+
+  
 });


### PR DESCRIPTION
I have some code that uses setTimeout that I use timekeeper to test with. I added handing of setTimeout functions based on freeze and travel. I also had to make some changes to travel() and freeze() in order for it to switch from one to the other without being reset (which would mess up the timeouts). I'd love to get this into the base library if you think it would be a good fit. Thanks for writing the base code, I use it extensively!

-Marcus