### PR TITLE
Distinct time

### DIFF
--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -69,7 +69,7 @@
 
       if (this instanceof NativeDate) {
 
-          if (!length && freeze) return freeze;
+          if (!length && freeze) return new NativeDate(freeze.getTime());
           if (!length && travel) return new NativeDate(time());
 
           var date = length == 1 && String(Y) === Y ? // isString(Y)

--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -1,5 +1,5 @@
 /**
- * Time keeper - EEasy testing of time-dependent code.
+ * Time keeper - Easy testing of time-dependent code.
  *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -28,30 +28,28 @@ describe('TimeKeeper', function() {
         tk.freeze(this.time);
       });
 
+      afterEach(function() {
+        tk.reset();
+      });
+
       it('freezes the time create with `new Date` to the supplied one', function() {
         sleep(10);
         var date = new Date;
         date.getTime().should.eql(this.time.getTime());
-        tk.reset();
       });
 
       it('freezes the time create with `Date#now` to the supplied one', function() {
         sleep(10);
         Date.now().should.eql(this.time.getTime());
-        tk.reset();
       });
 
       it('should not affect other date calls', function() {
         tk.freeze(this.time);
         (new Date(1330688329320)).getTime().should.eql(1330688329320);
-        tk.reset();
       });
 
       it('should return distinct frozen date objects', function() {
-				var date = new Date(), date1 = new Date();
-
-				date.should.not.equal(date1);
-        tk.reset();
+        (new Date()).should.not.equal(new Date());
       });
     });
   });

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -46,6 +46,13 @@ describe('TimeKeeper', function() {
         (new Date(1330688329320)).getTime().should.eql(1330688329320);
         tk.reset();
       });
+
+      it('should return distinct frozen date objects', function() {
+				var date = new Date(), date1 = new Date();
+
+				date.should.not.equal(date1);
+        tk.reset();
+      });
     });
   });
 


### PR DESCRIPTION
This is basically the same as #13 but with a (passing) test case built in.

I also refactored the tests slightly so that afterEach() is used to reset Timekeeper.