### PR TITLE
Freeze options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - 5.6.0

--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -103,7 +103,6 @@
   // Copy "native" methods explicitly; they may be non-enumerable
   FakeDate.UTC = NativeDate.UTC;
   FakeDate.parse = NativeDate.parse;
-  FakeDate.toString = NativeDate.toString;
 
   // Setup inheritance
   FakeDate.prototype = NativeDate.prototype;

--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -108,6 +108,28 @@
   FakeDate.prototype = NativeDate.prototype;
   FakeDate.prototype.constructor = NativeDate;
 
+	/**
+	 * Return an array representing the stack, with [0] referring to the calling
+	 * method
+	 */
+	function getStack() {
+		var fn = arguments.callee.caller, stackString = new Error().stack, stack = [];
+
+		// NodeJS
+		if(stackString) {
+			stack = new Error().stack.split(/\n/);
+
+			stack.shift();
+			stack.shift();
+		}
+
+		// Browser -- ???? Not obvious how this is done consistently without a lot of complexity.
+		else {
+		}
+
+		return stack;
+	}
+
   /**
    * Return the (next?) frozen date object
    */
@@ -119,10 +141,10 @@
     }
 
     if(frozen && frozen.file) {
-      var stack = new Error().stack.split(/\n/);
+      var stack = getStack();
 
       // The third stack frame up should contain the given filename
-      if(stack[3].indexOf(frozen.file) === -1) {
+      if(stack[2].indexOf(frozen.file) === -1) {
         // If not match, maybe push it back on the stack,
         if(freeze instanceof Array) {
           freeze.push(frozen);

--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -1,5 +1,5 @@
 /**
- * Time keeper - EEasy testing of time-dependent code.
+ * Time keeper - Easy testing of time-dependent code.
  *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
@@ -68,8 +68,9 @@
       var length = arguments.length;
 
       if (this instanceof NativeDate) {
+          var frozen = defrost();
 
-          if (!length && freeze) return freeze;
+          if (!length && frozen) return new NativeDate(frozen.getTime());
           if (!length && travel) return new NativeDate(time());
 
           var date = length == 1 && String(Y) === Y ? // isString(Y)
@@ -102,11 +103,44 @@
   // Copy "native" methods explicitly; they may be non-enumerable
   FakeDate.UTC = NativeDate.UTC;
   FakeDate.parse = NativeDate.parse;
+  FakeDate.toString = NativeDate.toString;
 
   // Setup inheritance
   FakeDate.prototype = NativeDate.prototype;
   FakeDate.prototype.constructor = NativeDate;
 
+  /**
+   * Return the (next?) frozen date object
+   */
+  function defrost() {
+    var frozen = freeze;
+
+    if(freeze && freeze.pop) {
+      frozen = freeze.pop();
+    }
+
+    if(frozen && frozen.file) {
+      var stack = new Error().stack.split(/\n/);
+
+      // The third stack frame up should contain the given filename
+      if(stack[3].indexOf(frozen.file) === -1) {
+        // If not match, maybe push it back on the stack,
+        if(freeze instanceof Array) {
+          freeze.push(frozen);
+        }
+
+        // Return null
+        frozen = null;
+      }
+    }
+
+    // And null the stack if it's exhausted
+    if(freeze && freeze.length === 0) {
+      freeze = null;
+    }
+
+    return frozen && frozen.date;
+  }
 
   /**
    * Replace the original now method.
@@ -120,25 +154,53 @@
    * @api public
    */
   FakeDate.now = function() {
-    if (freeze) return freeze.getTime();
+    var frozen = defrost();
+
+    if (frozen) return frozen.getTime();
     if (travel) return time();
     return NativeDate.now();
   };
 
   /**
-   * Set current Date Time and freeze it.
+   * Set current Date Time and freeze it, possibly only for
+   * a fixed number of accesses.
    *
    * @param {Object|String|Number} Date.
+   * @param {Object} args
+   *  * count: The number of times to return this date result
+   *  * file: A string that matches the filename which to freeze values for,
+   *    so that you can restrict the fake results to only certain contexts
    * @api public
    */
-  timekeeper.freeze = function(date) {
+  timekeeper.freeze = function(date, args) {
     useFakeDate();
+
+    args = args || {};
 
     if (typeof date !== 'object') {
       date = new NativeDate(date);
     }
 
-    freeze = date;
+    // A fixed number of times
+    if(args.count) {
+      if(!(freeze instanceof Array)) {
+        freeze = new Array();
+      }
+
+      for(var i = 0; i < args.count; i++) {
+        freeze.push({
+          date: new NativeDate(date.getTime()),
+          file: args.file
+        });
+      }
+    }
+    // Perpetually
+    else {
+      freeze = {
+        date: date,
+        file: args.file
+      }
+    }
   };
 
   /**

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -72,6 +72,30 @@ describe('TimeKeeper', function() {
           done();
         });
       });
+
+      // This functionality doesn't work in browsers because there's no way to
+      // get filenames from a stack trace, so just skip it in browsers.
+      if(typeof window === 'undefined') {
+        it('should only return the frozen time in the correct stack file', function(done) {
+          var _this = this;
+
+          tk.freeze(this.time, { count: 1, file: 'test/timekeeper.test.js-NOT' });
+
+          wait(function() {
+            Date.now().should.not.equal(_this.time.getTime());
+
+            tk.reset();
+
+            tk.freeze(_this.time, { count: 1, file: 'test/timekeeper.test.js' });
+
+            wait(function() {
+              Date.now().should.equal(_this.time.getTime());
+              done();
+            });
+          });
+        });
+      }
+
     });
   });
 

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -4,23 +4,12 @@
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
  */
-
-/**
- * Sleep implementation.
- *
- * Thanks to Stoyan Stefanov.
- * http://www.phpied.com/sleep-in-javascript/
- *
- * @param {Number} Milliseconds.
- */
-function sleep(milliseconds) {
-  var start = new Date().getTime();
-  for (var i = 0; i < 1e7; i++) {
-    if ((new Date().getTime() - start) > milliseconds) break;
-  }
-};
-
 describe('TimeKeeper', function() {
+  // Wait 10ms
+  function wait(cb) {
+    setTimeout(cb, 10);
+  }
+
   describe('freeze', function() {
     describe('when frozen', function() {
       beforeEach(function() {
@@ -28,40 +17,70 @@ describe('TimeKeeper', function() {
         tk.freeze(this.time);
       });
 
-      it('freezes the time create with `new Date` to the supplied one', function() {
-        sleep(10);
-        var date = new Date;
-        date.getTime().should.eql(this.time.getTime());
+      afterEach(function() {
         tk.reset();
       });
 
-      it('freezes the time create with `Date#now` to the supplied one', function() {
-        sleep(10);
-        Date.now().should.eql(this.time.getTime());
-        tk.reset();
+      it('freezes the time create with `new Date` to the supplied one', function(done) {
+        var _this = this;
+
+        wait(function() {
+          var date = new Date;
+          date.getTime().should.eql(_this.time.getTime());
+          done();
+        });
+      });
+
+      it('freezes the time create with `Date#now` to the supplied one', function(done) {
+        var _this = this;
+
+        wait(function() {
+          Date.now().should.eql(_this.time.getTime());
+          done();
+        });
       });
 
       it('should not affect other date calls', function() {
         tk.freeze(this.time);
         (new Date(1330688329320)).getTime().should.eql(1330688329320);
-        tk.reset();
       });
 
       it('should return distinct frozen date objects', function() {
-				var date = new Date(), date1 = new Date();
+        (new Date()).should.not.equal(new Date());
+      });
+    });
 
-				date.should.not.equal(date1);
+    describe('when frozen', function() {
+      beforeEach(function() {
+        this.time = new Date(1330688329321);
+      });
+
+      afterEach(function() {
         tk.reset();
+      });
+
+      it('should only return the frozen time N times', function(done) {
+        var _this = this;
+
+        tk.freeze(this.time, { count: 1 });
+
+        wait(function() {
+          var date = new Date(), date1 = new Date();
+
+          date.getTime().should.equal(_this.time.getTime());
+          date1.getTime().should.be.greaterThan(_this.time.getTime());
+          done();
+        });
       });
     });
   });
 
   describe('travel', function() {
     describe('when traveled', function() {
-      beforeEach(function() {
+      beforeEach(function(done) {
         this.time = new Date(1923701040000); // 2030
         tk.travel(this.time);
-        sleep(10);
+        wait(done);
       });
 
       describe('and used with `new Date`', function() {
@@ -73,7 +92,6 @@ describe('TimeKeeper', function() {
 
       describe('and used with `Date#now`', function() {
         it('should set the current date time to the supplied one', function() {
-          sleep(10);
           Date.now().should.be.greaterThan(this.time.getTime());
           tk.reset();
         });

--- a/test/timekeeper.test.js
+++ b/test/timekeeper.test.js
@@ -46,6 +46,13 @@ describe('TimeKeeper', function() {
         (new Date(1330688329320)).getTime().should.eql(1330688329320);
         tk.reset();
       });
+
+      it('should return distinct frozen date objects', function() {
+				var date = new Date(), date1 = new Date();
+
+				date.should.not.equal(date1);
+        tk.reset();
+      });
     });
   });
 


### PR DESCRIPTION
Add two options to `.freeze()`, in the form of a second parameter `args`:

`count` – Only return this date a specified number of times
`file` – Only return this date when called by this particular filename (matches on stack)

These additions were particularly useful when I had to test my code which had a number of asynchronous callbacks through third party libraries which would access the `Date` constructor a number of times before the instance I wanted to mock.

Being able to limit how often a particular date was returned and in which contexts made it much easier to test my particular functionality.

Unfortunately, it is not possible to trace the stack for filenames within WebKit, at least, so the functionality to pass the test in PhantomJS does not exist – So it's merely skipped for the browser tests.

I've also bumped up the node version in .travis.yml to keep the build system from harping about the old version of node, which seems to be what is causing the tests to fail.