### PR TITLE
fix(types): add optional parameter to freeze() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 export as namespace timekeeper;
 
 interface Timekeeper {
-  freeze(): void;
+  freeze(date?: Date): void;
   travel(date: Date): void;
   reset(): void;
   isKeepingTime(): boolean;


### PR DESCRIPTION
The freeze method incorrectly expected zero parameters.