### PR TITLE
Synchronize TypeScript definitions with API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 export as namespace timekeeper;
 
 interface Timekeeper {
-  freeze(date?: Date): void;
-  travel(date: Date): void;
+  freeze(date: Date | number | string): void;
+  travel(date: Date | number | string): void;
   reset(): void;
   isKeepingTime(): boolean;
 }


### PR DESCRIPTION
When using this library in a TypeScript project I noticed some differences between the declaration file and the actual implementation:

* `freeze()` should accept a `Date` or `string | number` which will be passed to `NativeDate()` (https://github.com/vesln/timekeeper/blob/c18c13c774c905531c2dd489934376705a2a0595/lib/timekeeper.js#L128-L134)
* The same holds for `travel()` (https://github.com/vesln/timekeeper/blob/c18c13c774c905531c2dd489934376705a2a0595/lib/timekeeper.js#L144-L150)

IMHO the `parameter` isn't really optional, because this will lead to `new Date(undefined)` which always results in a `Invalid Date` object. I cannot imaging any scenario where `FakeDate.now()` or `new FakeDate()` should return an `Invalid Date`.