### PR TITLE
timekeeper.freeze() without params

### DIFF
--- a/lib/timekeeper.js
+++ b/lib/timekeeper.js
@@ -135,7 +135,9 @@
     useFakeDate();
 
     if (typeof date !== 'object') {
-      date = new NativeDate(date);
+      date = date === undefined
+        ? new NativeDate()  
+        : new NativeDate(date);
     }
 
     freeze = date;


### PR DESCRIPTION
See issue https://github.com/vesln/timekeeper/issues/41